### PR TITLE
Added RefreshToken method

### DIFF
--- a/src/TokenCache.ts
+++ b/src/TokenCache.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import { Session } from './Types';
 import { bgGreen, bgYellow, green } from 'colors';
 import jwtDecode from 'jwt-decode';
+import axios from 'axios';
 
 export class TokenCache {
     private tokenCacheFile: string = '.token_cache';
@@ -52,5 +53,28 @@ export class TokenCache {
             }
             console.info(green('Fresh access token dropped into .token_cache'));
         });
+    }
+
+    public async RefreshToken(session: Session) {
+        let endpoint = `${session.ApiGatewayUri}refreshtoken?api-version=${session.ApiGatewayVersion}`;
+
+        let response = await axios.get(endpoint,
+            {
+                headers: {
+                    Authorization: `Bearer ${session.AccessToken}`
+                }
+            });
+
+        let freshCookie: string | null = null;
+        
+        try {
+            let cookie: string = response.headers["set-cookie"].toString();
+            let freshCookie = cookie.split(',Authorization_Api=')[0];
+        }
+        catch (e) {
+            console.error("Error when calling /refreshtoken: Missing or unexpected set-cookie header.");
+        }
+
+        return freshCookie;
     }
 }

--- a/src/TokenCache.ts
+++ b/src/TokenCache.ts
@@ -3,6 +3,7 @@ import { Session } from './Types';
 import { bgGreen, bgYellow, green } from 'colors';
 import jwtDecode from 'jwt-decode';
 import axios from 'axios';
+import colors from 'colors';
 
 export class TokenCache {
     private tokenCacheFile: string = '.token_cache';
@@ -72,7 +73,7 @@ export class TokenCache {
             let freshCookie = cookie.split(',Authorization_Api=')[0];
         }
         catch (e) {
-            console.error("Error when calling /refreshtoken: Missing or unexpected set-cookie header.");
+            console.error(colors.yellow("Error when calling /refreshtoken: Missing or unexpected set-cookie header."));
         }
 
         return freshCookie;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,6 +2,7 @@ export type Session = {
     AccessToken: string;
     ApiGatewayUri: string;
     ApiGatewayVersion: string;
+    Cookie?: string;
 }
 
 

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -254,6 +254,7 @@ async function downloadVideo(videoUrls: string[], outputDirectory: string, sessi
                 console.log(`ffmpeg returned an error: ${err.message}`);
             })
             .on('end', () => {
+                //pbar.update(100);
                 console.log(colors.green(`\nDownload finished: ${outputPath}`));
             });
     }));


### PR DESCRIPTION
* Added `RefreshToken` method to TokenCache.ts

Not yet used by our code, but ready to be used.

## What's this for and how do we use it?

Instead of calling the HLS URL with the access token we extract from sessionInfo (on login), we take the same access token, call `TokenCache.RefreshToken()` and get back the value of a `Cookie` header that we can now pass to ffmpeg. Unfortunately the fresh token is now a cookie, i am unable to get a fresh Bearer token. 

This cookie, if unrolled as an opaque access token inside, but that doesn't stand on its own as Bearer (returns 401 Unauthorized) so the full cookie must be sent as `Cookie:`.

MS Stream API works in mysterious ways.


## Why?

This addresses https://github.com/snobu/destreamer/issues/43, each video in _to be downloaded_ array can now be downloaded with a fresh token that's good for one full hour. Since the validation of the token is performed remotely only once (when we send the request), even if we take two hours to download a video it won't matter, it will succeed.

We should call RefreshToken even for the first video in our array since the cached access token may only have a few minutes left before expiring.

The metadata is fetched for all videos on startup (with the original access token), so we don't need to worry about that part.

## Caveats?

ffmpeg must now be called with `Cookie: <value returned by RefreshToken()>` instead of an Authorization header.

`RefreshToken()` may come back as null (as the API call that i make is highly experimental), so our implementation can decide if we continue with a new "cookie" token or we fall back to our original access token.

## Sample usage

```javascript
let freshCookie: string | null = tokenCache.RefreshToken(session);
if (freshCookie) {
    // Call ffmpeg with a `Cookie: <value of freshCookie>` header
}
else {
    // Call ffmpeg with original access token (Authorization: Bearer ...)
}
```

We should have a method that returns the corrent header for ffmpeg so we don't pollute the already complex ffmpeg wrapper with unnecessary ifs.