### PR TITLE
Adding temporary bootstrapers until we move to single binary releases

### DIFF
--- a/destreamer.cmd
+++ b/destreamer.cmd
@@ -1,0 +1,1 @@
+node.exe build\src\destreamer.js %*

--- a/destreamer.ps1
+++ b/destreamer.ps1
@@ -1,0 +1,1 @@
+node.exe build\src\destreamer.js $args

--- a/destreamer.sh
+++ b/destreamer.sh
@@ -1,0 +1,1 @@
+node build/src/destreamer.js "$@"


### PR DESCRIPTION
I'd be happy to use `npm start --videoUrls <>` instead if users would not have to write it like this:

```
npm start -- --videoUrls <>
```

Does anyone have a better idea? Can we convince npm to go pick our arguments without the double slash signaling? Is there a better way to bootstrap our app?