### PR TITLE
Reintroduce Node 8.x support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [8.x, 10.x, 12.x, 13.x]
 
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Hopefully this doesn't break the end user agreement for Microsoft Stream. Since 
 
 ## Prereqs
 
-- **Node.js**: You'll need Node.js v10 or higher. A GitHub Action runs tests on all major Node versions on every commit.
+- **Node.js**: You'll need Node.js version 8.0 or higher. A GitHub Action runs tests on all major Node versions on every commit.
 - **npm**: usually comes with Node.js, type `npm` in your terminal to check for its presence
 - [**ffmpeg**][ffmpeg]: a recent version (year 2019 or above), in `$PATH` or in the same directory as this README file (project root).
 - **git**: one or more npm dependencies require git. Install git with your favorite package manager or https://git-scm.com/downloads

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -16,6 +16,7 @@ import puppeteer from 'puppeteer';
 import colors from 'colors';
 import path from 'path';
 import fs from 'fs';
+import { URL } from 'url';
 import sanitize from 'sanitize-filename';
 import cliProgress from 'cli-progress';
 
@@ -233,7 +234,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             ffmpegCmd.spawn();
         });
         
-        process.off('SIGINT', cleanupFn);
+        process.removeListener('SIGINT', cleanupFn);
     }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "rootDirs": ["./src", "./test"],
     "outDir": "./build",
-    "target": "ES2019",             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "ES2017",             /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "strict": true,                 /* Enable all strict type-checking options. */
     "moduleResolution": "node",     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */


### PR DESCRIPTION
Turns out we can still support Node 8.x with minimal changes.

In this PR -
* Downgrade TypeScript target to [ES2017]((https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping)) from ES2019
TS compiler still outputs async/await .js files and will not polyfill __awaiter junk, so we're good there.
* Explicit import for the URL module: `import { URL } from 'url'` (Node 8.x cries wolf otherwise)
* We drop `process.off` in favor of `process.removeListener`, since there's no `off` in Node 8.x (also hinted by [this issue](https://github.com/snobu/destreamer/issues/76))
* Update README to list Node 8.x as supported