### PR TITLE
Workaround for Cygwin/MSYS progress bar

### DIFF
--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -154,6 +154,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             barCompleteChar: '\u2588',
             barIncompleteChar: '\u2591',
             format: 'progress [{bar}] {percentage}% {speed} {eta_formatted}',
+            // process.stdout.columns may return undefined in some terminals (Cygwin/MSYS)
             barsize: Math.floor((process.stdout.columns || 30) / 3),
             stopOnComplete: true,
             hideCursor: true,

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -215,6 +215,11 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             pbar.update(currentChunks, {
                 speed: data.bitrate
             });
+
+            // Graceful fallback in case we can't get columns (Cygwin/MSYS)
+            if (!process.stdout.columns) {
+                process.stdout.write(`--- Speed: ${data.bitrate}, Cursor: ${data.out_time}\r`);
+            }
         });
 
         ffmpegCmd.on('error', (error: any) => {

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -148,12 +148,6 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         console.log(outputDirectories);
 
     const outDirsIdxInc = outputDirectories.length > 1 ? 1:0;
-    if (!process.stdout.columns) {
-        console.info(colors.red('Unable to get number of columns from terminal.\n' +
-            'This happens sometimes in Cygwin/MSYS.\n' +
-            'No progress bar can be rendered, ' +
-            'however the download process should not be affected.'));
-    }
     for (let i=0, j=0, l=metadata.length; i<l; ++i, j+=outDirsIdxInc) {
         const video = metadata[i];
         const pbar = new cliProgress.SingleBar({
@@ -174,6 +168,12 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             await drawThumbnail(video.posterImage, session.AccessToken);
 
         console.info('Spawning ffmpeg with access token and HLS URL. This may take a few seconds...');
+        if (!process.stdout.columns) {
+            console.info(colors.red('Unable to get number of columns from terminal.\n' +
+                'This happens sometimes in Cygwin/MSYS.\n' +
+                'No progress bar can be rendered, ' +
+                'however the download process should not be affected.'));
+        }
 
         // Try to get a fresh cookie, else gracefully fall back
         // to our session access token (Bearer)

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -148,6 +148,12 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         console.log(outputDirectories);
 
     const outDirsIdxInc = outputDirectories.length > 1 ? 1:0;
+    if (!process.stdout.columns) {
+        console.info(colors.red('Unable to get number of columns from terminal.\n' +
+            'This happens sometimes in Cygwin/MSYS.\n' +
+            'No progress bar can be rendered, ' +
+            'however the download process should not be affected.'));
+    }
     for (let i=0, j=0, l=metadata.length; i<l; ++i, j+=outDirsIdxInc) {
         const video = metadata[i];
         const pbar = new cliProgress.SingleBar({

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -171,8 +171,8 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         if (!process.stdout.columns) {
             console.info(colors.red('Unable to get number of columns from terminal.\n' +
                 'This happens sometimes in Cygwin/MSYS.\n' +
-                'No progress bar can be rendered, ' +
-                'however the download process should not be affected.'));
+                'No progress bar can be rendered, however the download process should not be affected.\n\n' +
+                'Please use PowerShell or cmd.exe to run destreamer.'));
         }
 
         // Try to get a fresh cookie, else gracefully fall back

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -148,18 +148,13 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         console.log(outputDirectories);
 
     const outDirsIdxInc = outputDirectories.length > 1 ? 1:0;
-    let columns = 30;
-    console.log(`process.stdout.columns = ${process.stdout.columns}`)
-    if (!process.stdout.columns || process.stdout.columns === 0) {
-        columns = process.stdout.columns
-    }
     for (let i=0, j=0, l=metadata.length; i<l; ++i, j+=outDirsIdxInc) {
         const video = metadata[i];
         const pbar = new cliProgress.SingleBar({
             barCompleteChar: '\u2588',
             barIncompleteChar: '\u2591',
             format: 'progress [{bar}] {percentage}% {speed} {eta_formatted}',
-            barsize: Math.floor(columns / 3),
+            barsize: Math.floor((process.stdout.columns || 30) / 3),
             stopOnComplete: true,
             hideCursor: true,
         });

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -149,6 +149,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
 
     const outDirsIdxInc = outputDirectories.length > 1 ? 1:0;
     let columns = 30;
+    console.log(`process.stdout.columns = ${process.stdout.columns}`)
     if (!process.stdout.columns || process.stdout.columns === 0) {
         columns = process.stdout.columns
     }

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -148,13 +148,17 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         console.log(outputDirectories);
 
     const outDirsIdxInc = outputDirectories.length > 1 ? 1:0;
+    let columns = 30;
+    if (!process.stdout.columns || process.stdout.columns === 0) {
+        columns = process.stdout.columns
+    }
     for (let i=0, j=0, l=metadata.length; i<l; ++i, j+=outDirsIdxInc) {
         const video = metadata[i];
         const pbar = new cliProgress.SingleBar({
             barCompleteChar: '\u2588',
             barIncompleteChar: '\u2591',
             format: 'progress [{bar}] {percentage}% {speed} {eta_formatted}',
-            barsize: Math.floor(process.stdout.columns / 3),
+            barsize: Math.floor(columns / 3),
             stopOnComplete: true,
             hideCursor: true,
         });

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -172,7 +172,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             console.info(colors.red('Unable to get number of columns from terminal.\n' +
                 'This happens sometimes in Cygwin/MSYS.\n' +
                 'No progress bar can be rendered, however the download process should not be affected.\n\n' +
-                'Please use PowerShell or cmd.exe to run destreamer.'));
+                'Please use PowerShell or cmd.exe to run destreamer on Windows.'));
         }
 
         // Try to get a fresh cookie, else gracefully fall back


### PR DESCRIPTION
On some Cygwin/MSYS terminals (MSYS rxvt exhibits this problem every time), `process.stdout.columns` returns `undefined`, because why not, what did you think this is, software engineering or engineer softening?

![image](https://user-images.githubusercontent.com/6472374/79914286-b4352d00-842d-11ea-94b6-0085f46490d5.png)

Anywho... `barsize` here will fail and throw the dreaded `RangeError: Invalid array length` (ref https://github.com/snobu/destreamer/issues/83)

 ```js
new cliProgress.SingleBar({
            barCompleteChar: '\u2588',
            barIncompleteChar: '\u2591',
            format: 'progress [{bar}] {percentage}% {speed} {eta_formatted}',
            barsize: Math.floor(process.stdout.columns / 3),
            stopOnComplete: true,
```

Temporary fix is to handle the undefined case and fall back to an integer. The progress bar won't render at all but the download works.

Current behavior -
![image](https://user-images.githubusercontent.com/6472374/79912993-923aab00-842b-11ea-9bc1-92b682c82203.png)

New behavior after this PR gets merged -
![image](https://user-images.githubusercontent.com/6472374/79912311-800c3d00-842a-11ea-8312-3a8cb3b65285.png)
