### PR TITLE
Add mid-download token refresh, fix headers length overflow bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@
 node_modules
 videos
 release
-swagger.json
-cc.json
+build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,10 +9,10 @@
             "type": "node",
             "request": "launch",
             "name": "Launch Program",
-            "program": "${workspaceFolder}/destreamer.js",
+            "program": "${workspaceFolder}/build/src/destreamer.js",
             "args": [
-                "--videoUrls",
-                "https://web.microsoftstream.com/video/6f1a382b-e20c-44c0-98fc-5608286e48bc"
+                "-i",
+                "https://web.microsoftstream.com/video/ce4da1ff-0400-86ec-2ad6-f1ea83412074" // Bacon and Eggs
             ]
         }
     ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,6 +7,7 @@
 
         {
             "type": "node",
+            "runtimeArgs": ["--max-http-header-size", "32768"],
             "request": "launch",
             "name": "Launch Program",
             "program": "${workspaceFolder}/build/src/destreamer.js",

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This release would not have been possible without the code and time contributed 
 - Major code refactoring
 - Dramatically improved error handling
 - We now have a token cache so we can reuse access tokens. This really means that within one hour you need to perform the interactive browser login only once.
-- We removed the dependency on `youtube-dl`.
+- We removed the dependency on `youtube-dl`
 - Getting to the HLS URL is dramatically more reliable as we dropped parsing the DOM for the video element in favor of calling the Microsoft Stream API
-- Fixed access token lifetime bugs (you no longer get a 403 Forbidden midway though your download list). Still one outstanding edge case here, see _Found a bug_ at the bottom for more.
+- Fixed access token lifetime bugs (you no longer get a 403 Forbidden midway though your download list)
 - Fixed a major 2FA bug that would sometimes cause a timeout in our code
 - Fixed a wide variety of other bugs, maybe introduced a few new ones :)
 
@@ -126,9 +126,7 @@ Contributions are welcome. Open an issue first before sending in a pull request.
 
 ## Found a bug?
 
-There is one outstanding bug that you may hit: if you download two or more videos in one go, if one of the videos take more than one hour to complete, the next download will fail as the cookie is now expired. We'll patch this soon.
-
-For other bugs, please open an [issue](https://github.com/snobu/destreamer/issues) and we'll look into it.
+Please open an [issue](https://github.com/snobu/destreamer/issues) and we'll look into it.
 
 
 [ffmpeg]: https://www.ffmpeg.org/download.html

--- a/destreamer.cmd
+++ b/destreamer.cmd
@@ -1,1 +1,10 @@
+@ECHO OFF
+
+node.exe --version | findstr "v8."
+IF %ERRORLEVEL% EQU 0 GOTO Node8
+
+node.exe --max-http-header-size 32768 build\src\destreamer.js %*
+
+:Node8
 node.exe build\src\destreamer.js %*
+

--- a/destreamer.ps1
+++ b/destreamer.ps1
@@ -1,1 +1,8 @@
-node.exe build\src\destreamer.js $args
+$NodeVersion = Invoke-Expression "node.exe --version"
+if ($NodeVersion.StartsWith("v8.")) {
+    node.exe build\src\destreamer.js $args
+}
+else {
+    node.exe --max-http-header-size 32768 build\src\destreamer.js $args
+}
+

--- a/destreamer.sh
+++ b/destreamer.sh
@@ -1,1 +1,8 @@
-node build/src/destreamer.js "$@"
+#!/usr/bin/env bash
+NODE_VERSION=$(node --version)
+
+if [[ $NODE_VERSION == "v8."* ]]; then
+    node build/src/destreamer.js "$@"
+else
+    node --max-http-header-size 32768 build/src/destreamer.js "$@"
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -481,9 +481,9 @@
       }
     },
     "cli-progress": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.7.0.tgz",
-      "integrity": "sha512-xo2HeQ3vNyAO2oYF5xfrk5YM6jzaDNEbeJRLAQir6QlH54g4f6AXW+fLyJ/f12gcTaCbJznsOdQcr/yusp/Kjg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.8.0.tgz",
+      "integrity": "sha512-3e+m7ecKbVTF2yo186vrrt/5217ZwE64z61kMwhSFmgrF3qZiTUuV9Fdh2RyzSkhLRfsqFf721KiUDEAJlP5pA==",
       "requires": {
         "colors": "^1.1.2",
         "string-width": "^4.2.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "build/src/destreamer.js",
   "bin": "build/src/destreamer.js",
   "scripts": {
-    "build": "echo Transpiling TypeScript to JavaScript... & node node_modules/typescript/bin/tsc & echo Destreamer was built successfully.",
+    "build": "echo Transpiling TypeScript to JavaScript... && node node_modules/typescript/bin/tsc && echo Destreamer was built successfully.",
     "test": "mocha build/test"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "build/src/destreamer.js",
   "bin": "build/src/destreamer.js",
   "scripts": {
-    "build": "echo Transpiling TypeScript to JavaScript... & node node_modules/typescript/bin/tsc --listEmittedFiles",
+    "build": "echo Transpiling TypeScript to JavaScript... & node node_modules/typescript/bin/tsc & echo Destreamer was built successfully.",
     "test": "mocha build/test"
   },
   "keywords": [],

--- a/src/TokenCache.ts
+++ b/src/TokenCache.ts
@@ -59,13 +59,20 @@ export class TokenCache {
     public async RefreshToken(session: Session): Promise<string | null> {
         let endpoint = `${session.ApiGatewayUri}refreshtoken?api-version=${session.ApiGatewayVersion}`;
 
-        let response = await axios.get(endpoint,
-            {
-                headers: {
-                    Authorization: `Bearer ${session.AccessToken}`
-                }
-            });
+        let headers: Function = (): object => {
+            if (session.Cookie) {
+                return {
+                    Cookie: session.Cookie
+                };
+            }
+            else {
+                return {
+                    Authorization: 'Bearer ' + session.AccessToken
+                };
+            }
+        }
 
+        let response = await axios.get(endpoint, { headers: headers() });
         let freshCookie: string | null = null;
         
         try {

--- a/src/TokenCache.ts
+++ b/src/TokenCache.ts
@@ -56,13 +56,13 @@ export class TokenCache {
         });
     }
 
-    public async RefreshToken(session: Session): Promise<string | null> {
+    public async RefreshToken(session: Session, cookie?: string | null): Promise<string | null> {
         let endpoint = `${session.ApiGatewayUri}refreshtoken?api-version=${session.ApiGatewayVersion}`;
 
         let headers: Function = (): object => {
-            if (session.Cookie) {
+            if (cookie) {
                 return {
-                    Cookie: session.Cookie
+                    Cookie: cookie
                 };
             }
             else {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,7 +2,6 @@ export type Session = {
     AccessToken: string;
     ApiGatewayUri: string;
     ApiGatewayVersion: string;
-    Cookie?: string;
 }
 
 export type Metadata = {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -2,6 +2,7 @@ export type Session = {
     AccessToken: string;
     ApiGatewayUri: string;
     ApiGatewayVersion: string;
+    Cookie?: string;
 }
 
 export type Metadata = {

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -193,7 +193,9 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         if (freshCookie) {
             lastTokenRefresh = Date.now();
             session.Cookie = freshCookie;
-            console.info(colors.green('Using a fresh cookie.'));
+            if (argv.verbose) {
+                console.info(colors.green('Using a fresh cookie.'));
+            }
             // eslint-disable-next-line no-useless-escape
             headers = `Cookie:\ ${freshCookie}`;
         }
@@ -201,7 +203,9 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         const RefreshTokenMaybe = async (): Promise<void> => {
             let elapsed = Date.now() - lastTokenRefresh;
             if (elapsed > REFRESH_TOKEN_INTERVAL * 1000) {
-                console.info(colors.green('\nRefreshing access token...'));
+                if (argv.verbose) {
+                    console.info(colors.green('\nRefreshing access token...'));
+                }
                 lastTokenRefresh = Date.now();
                 freshCookie = await tokenCache.RefreshToken(session);
             }

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -25,7 +25,7 @@ const tokenCache = new TokenCache();
 
 // The cookie lifetime is one hour,
 // let's refresh every 3000 seconds.
-const REFRESH_TOKEN_INTERVAL = 60;
+const REFRESH_TOKEN_INTERVAL = 3000;
 
 async function init() {
     setProcessEvents(); // must be first!
@@ -226,7 +226,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
                 fs.unlinkSync(outputPath);
             } catch(e) {}
         }
-        
+
         pbar.start(video.totalChunks, 0, {
             speed: '0'
         });

--- a/test/test.ts
+++ b/test/test.ts
@@ -7,27 +7,19 @@ import fs from 'fs';
 let browser: any;
 let page: any;
 
-before(async () => {
-    browser = await puppeteer.launch({
-        headless: true,
-        args: ['--disable-dev-shm-usage']
-    });
-    page = await browser.newPage();
-});
-
 describe('Puppeteer', () => {
     it('should grab GitHub page title', async () => {
-        await page.goto("https://github.com/", { waitUntil: 'networkidle2' });
+        browser = await puppeteer.launch({
+            headless: true,
+            args: ['--disable-dev-shm-usage']
+        });
+        page = await browser.newPage();
+        await page.goto("https://github.com/", { waitUntil: 'load' });
         let pageTitle = await page.title();
         assert.equal(true, pageTitle.includes('GitHub'));
-
+        await browser.close();
     }).timeout(15000); // yeah, this may take a while...
 });
-
-after(async () => {
-    await browser.close();
-});
-
 
 describe('Destreamer', () => {
     it('should parse and sanitize URL list from file', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "module": "commonjs",           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "strict": true,                 /* Enable all strict type-checking options. */
     "moduleResolution": "node",     /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "esModuleInterop": true         /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "sourceMap": true,
   }
 }


### PR DESCRIPTION
* Added mid-download token refresh (it's really a cookie not a Bearer buy anyway). We hook into fessonia's `.update` event, do a time delta and check if we need to refresh the token and if so, we go do it every 3000 seconds. I bit into the `setInterval()` poisoned apple at first, oh boy what a trip has that been...
    <img src="https://user-images.githubusercontent.com/6472374/80288536-421c5b00-8741-11ea-8c26-7dc5f14c677e.png" width="300" />

* Added fix for Node headers overflow (i'm very surprised we didn't get any issue on this yet). [This commit](https://github.com/nodejs/node/commit/92231a56d9) introduced a soft limit of 8KB for HTTP headers which our fat Cookies would easily overflow. The Node devs raised this limit again in 13.x, but 12 and versions below it have it set to 8KB by default. To add insult to injury Node 8.x doesn't boot with the header parameter passed to it so we need to if around that at bootstrap.

* `cli-progress` upped to 3.8.0 via `project-lock.json`. It happened so i didn't fight it. Seems to work fine.

* Slightly refactored the Puppeteer test in the hope GItHub Actions would show us mercy
