### PR TITLE
Add noDeleteOnError cmd argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ Options:
   --verbose, -v            Print additional information to the console (use this
                            before opening an issue on GitHub)
                                                       [boolean] [default: false]
+  --noCleanup, --nc        Don't delete the downloaded video file when an FFmpeg
+                           error occurs               [boolean] [default: false]
 ```
 
 Download a video -

--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -54,6 +54,13 @@ export const argv = yargs.options({
         type: 'boolean',
         default: false,
         demandOption: false
+    },
+	noDeleteOnError: {
+	alias: 'd',
+	describe: `Don't delete the downloaded video file when an FFmpeg error occurs`,
+	type: 'boolean',
+	default: false,
+	demandOption: false
     }
 })
 /**

--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -55,12 +55,12 @@ export const argv = yargs.options({
         default: false,
         demandOption: false
     },
-	noDeleteOnError: {
-	alias: 'd',
-	describe: `Don't delete the downloaded video file when an FFmpeg error occurs`,
-	type: 'boolean',
-	default: false,
-	demandOption: false
+    noCleanup: {
+        alias: 'nc',
+        describe: `Don't delete the downloaded video file when an FFmpeg error occurs`,
+        type: 'boolean',
+        default: false,
+        demandOption: false
     }
 })
 /**

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -195,6 +195,9 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         const cleanupFn = function () {
             pbar.stop();
 
+           if (argv.noCleanup)
+               return;
+
             try {
                 fs.unlinkSync(outputPath);
             } catch(e) {}
@@ -223,12 +226,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
         });
 
         ffmpegCmd.on('error', (error: any) => {
-            pbar.stop();
-
-            try {
-                if (!argv.noCleanup)
-                    fs.unlinkSync(outputPath);
-            } catch (e) {}
+            cleanupFn();
 
             console.log(`\nffmpeg returned an error: ${error.message}`);
             process.exit(ERROR_CODE.UNK_FFMPEG_ERROR);

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -226,7 +226,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             pbar.stop();
 
             try {
-                if (!argv.noDeleteOnError)
+                if (!argv.noCleanup)
                     fs.unlinkSync(outputPath);
             } catch (e) {}
 

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -226,7 +226,8 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             pbar.stop();
 
             try {
-                fs.unlinkSync(outputPath);
+                if (!argv.noDeleteOnError)
+                    fs.unlinkSync(outputPath);
             } catch (e) {}
 
             console.log(`\nffmpeg returned an error: ${error.message}`);


### PR DESCRIPTION
I ran into #82 a few times again since I closed it. It intermittently shows up, I don't have a real explanation for it yet. However, even while it reports an error, the video file is flawless, and it gets deleted.

I added a cmd line option called `noDeleteOnError`, with alias `d`, which defaults to `false`, and a check in `destreamer.ts`, when FFmpeg error handler is called, so the file won't get deleted if the argument is passed.