### PR TITLE
[eslint] Add newline before return and mandate curly braces

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,8 @@
         "padding-line-between-statements": [
             "error",
             { "blankLine": "always", "prev": "*", "next": "return" }
-        ]
+        ],
+        "brace-style": [2, "stroustrup", { "allowSingleLine": false }],
+        "curly": ["error", "all"]
     }
 }


### PR DESCRIPTION
Any complaints here?
Anything else we should enforce?

* Enforce newline before return
```javascript
//ok
function a() {
    // stuff

    return result;
}

//not ok
function a() {
    // stuff
    return result;
}
```

* Enforce curly braces everywhere:
```javascript
//ok
if (a === b) {
    c++;
}

//not ok
if (a === b)
    c++;
```

* Enforce stroustrup brace style
```javascript
//ok
if (a === b) {
    c++;
}

//not ok
if (a === b)
{
    c++;
}

```