### PR TITLE
Add option to change encoder and container

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Options:
                                                       [boolean] [default: false]
   --noCleanup, --nc        Don't delete the downloaded video file when an FFmpeg
                            error occurs               [boolean] [default: false]
+  --encodeVideo, --ev      Encode the video with a specify encoder. Set to
+                           "none" to disable video.   [string] [default: "copy"]
+  --encodeAudio, --ea      Encode the audio with a specify encoder. Set to
+                           "none" to disable audio.   [string] [default: "copy"]
+  --format, -F             The file format of the output file(s)
+                                                       [string] [default: "mkv"]
 ```
 
 Download a video -

--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -61,6 +61,27 @@ export const argv = yargs.options({
         type: 'boolean',
         default: false,
         demandOption: false
+    },
+    encodeVideo: {
+        alias: 'ev',
+        describe: 'Encode the video with a specify encoder. Set to "none" to disable video.',
+        type: 'string',
+        default: 'copy',
+        demandOption: false
+    },
+    encodeAudio: {
+        alias: 'ea',
+        describe: 'Encode the audio with a specify encoder. Set to "none" to disable audio.',
+        type: 'string',
+        default: 'copy',
+        demandOption: false
+    },
+    format: {
+        alias: 'F',
+        describe: 'The file format of the output file(s)',
+        type: 'string',
+        default: 'mkv',
+        demandOption: false
     }
 })
 /**

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -212,13 +212,16 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
             }
         };
 
-        const outputPath = outputDirectories[j] + path.sep + video.title + '.mp4';
+        const outputPath = outputDirectories[j] + path.sep + video.title + '.' + argv.format;
         const ffmpegInpt = new FFmpegInput(video.playbackUrl, new Map([
             ['headers', headers]
         ]));
-        const ffmpegOutput = new FFmpegOutput(outputPath);
+        const ffmpegOutput = new FFmpegOutput(outputPath, new Map([
+            argv.encodeAudio === 'none' ? ['an', null] : ['c:a', argv.encodeAudio],
+            argv.encodeVideo === 'none' ? ['vn', null] : ['c:v', argv.encodeVideo]
+        ]));
         const ffmpegCmd = new FFmpegCommand();
-        
+
         const cleanupFn = (): void => {
             pbar.stop();
 
@@ -271,7 +274,7 @@ async function downloadVideo(videoUrls: string[], outputDirectories: string[], s
 
             ffmpegCmd.spawn();
         });
-        
+
         process.removeListener('SIGINT', cleanupFn);
     }
 }


### PR DESCRIPTION
This change enables the user to select a specific container and/or encoder for the output. As this change forces `ffmpeg` to use `copy` by default, `destreamer` now uses `mkv` as default output. This might be needed when MS Streams doesn't offer a `mp4` compatible stream. `mkv` offers much more support.

Fixes #113 