### PR TITLE
Don't wait for email field if username isn't provided

### DIFF
--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -60,11 +60,14 @@ async function DoInteractiveLogin(url: string, username?: string): Promise<Sessi
     console.log('Navigating to login page...');
 
     await page.goto(url, { waitUntil: 'load' });
-    await page.waitForSelector('input[type="email"]');
 
     if (username) {
+        await page.waitForSelector('input[type="email"]');
         await page.keyboard.type(username);
         await page.click('input[type="submit"]');
+    } else {
+        // If a username was not provided we let the user take actions that
+        // lead up to the video page.
     }
 
     await browser.waitForTarget(target => target.url().includes(videoId), { timeout: 150000 });


### PR DESCRIPTION
Destreamer waits for the `<input type="email">` tag to appear. But in
some corporate environments, like mine, the videos are protected by
proxies, which in turn ar protected by SSO/SAML. Since the SSO login may
not have that input field's type set to 'email', the wait would
eventually timeout.

With this fix we wait for the "email" field only if --username option
was used. Otherwise we let the user take the actions manually to take
the browser to the video page.