### PR TITLE
fix typo & sanitize video names on win32

### DIFF
--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -72,7 +72,7 @@ export const argv: any = yargs.options({
     },
     closedCaptions: {
         alias: 'cc',
-        describe: 'Check if closed captions are aviable and let the user choose which one to download (will not ask if only one aviable)',
+        describe: 'Check if closed captions are available and let the user choose which one to download (will not ask if only one available)',
         type: 'boolean',
         default: false,
         demandOption: false
@@ -183,8 +183,8 @@ function isOutputTemplateValid(argv: any): boolean {
         while (match) {
             if (!templateElements.includes(match[1])) {
                 logger.error(
-                    `'${match[0]}' is not aviable as a template element \n` +
-                    `Aviable templates elements: '${templateElements.join("', '")}' \n`,
+                    `'${match[0]}' is not available as a template element \n` +
+                    `Available templates elements: '${templateElements.join("', '")}' \n`,
                     { fatal: true }
                 );
 

--- a/src/VideoUtils.ts
+++ b/src/VideoUtils.ts
@@ -151,9 +151,13 @@ export function createUniquePath(videos: Array<Video>, outDirs: Array<string>, t
         while (!skip && fs.existsSync(path.join(outDirs[index], finalTitle + '.' + format))) {
             finalTitle = `${title}.${++i}`;
         }
-       
-        video.outPath = path.join(outDirs[index], `${sanitizeWindowsName(finalTitle, { replacement: "_" })}.${format}`);
-        
+
+        const finalFileName = `${finalTitle}.${format}`;
+        const cleanFileName = sanitizeWindowsName(finalFileName, { replacement: "_" });
+        if (finalFileName !== cleanFileName) logger.warn(`Not a valid Windows file name: "${finalFileName}".\nReplacing invalid characters with underscores to preserve cross-platform consistency.`);
+
+        video.outPath = path.join(outDirs[index], finalFileName);
+
     });
 
     return videos;

--- a/src/VideoUtils.ts
+++ b/src/VideoUtils.ts
@@ -153,7 +153,12 @@ export function createUniquePath(videos: Array<Video>, outDirs: Array<string>, t
         }
 
 
-        video.outPath = path.join(outDirs[index], finalTitle + '.' + format);
+        if ("win32" == (require('os').platform() || "win32")) { // 
+            video.outPath = path.join(outDirs[index], `${sanitizeWindowsName(finalTitle, { replacement: "_" })}.${format}`);
+        } else {
+            video.outPath = path.join(outDirs[index], finalTitle + '.' + format);
+        }
+
     });
 
     return videos;

--- a/src/VideoUtils.ts
+++ b/src/VideoUtils.ts
@@ -68,7 +68,7 @@ export async function getVideoInfo(videoGuids: Array<string>, session: Session, 
         let response: AxiosResponse<any> | undefined =
             await apiClient.callApi('videos/' + guid + '?$expand=creator', 'get');
 
-        title = response?.data['name'];
+        title = sanitizeWindowsName(response?.data['name']);
 
         duration = isoDurationToString(response?.data.media['duration']);
 

--- a/src/VideoUtils.ts
+++ b/src/VideoUtils.ts
@@ -68,7 +68,7 @@ export async function getVideoInfo(videoGuids: Array<string>, session: Session, 
         let response: AxiosResponse<any> | undefined =
             await apiClient.callApi('videos/' + guid + '?$expand=creator', 'get');
 
-        title = sanitizeWindowsName(response?.data['name']);
+        title = response?.data['name'];
 
         duration = isoDurationToString(response?.data.media['duration']);
 

--- a/src/VideoUtils.ts
+++ b/src/VideoUtils.ts
@@ -24,14 +24,14 @@ function publishedTimeToString(date: string): string {
     const minutes: string = dateJs.getMinutes().toString();
     const seconds: string = dateJs.getSeconds().toString();
 
-    return `${hours}:${minutes}:${seconds}`;
+    return `${hours}.${minutes}.${seconds}`;
 }
 
 
 function isoDurationToString(time: string): string {
     const duration: Duration = parseDuration(time);
 
-    return `${duration.hours ?? '00'}:${duration.minutes ?? '00'}:${duration.seconds?.toFixed(0) ?? '00'}`;
+    return `${duration.hours ?? '00'}.${duration.minutes ?? '00'}.${duration.seconds?.toFixed(0) ?? '00'}`;
 }
 
 
@@ -151,14 +151,9 @@ export function createUniquePath(videos: Array<Video>, outDirs: Array<string>, t
         while (!skip && fs.existsSync(path.join(outDirs[index], finalTitle + '.' + format))) {
             finalTitle = `${title}.${++i}`;
         }
-
-
-        if ("win32" == (require('os').platform() || "win32")) { // 
-            video.outPath = path.join(outDirs[index], `${sanitizeWindowsName(finalTitle, { replacement: "_" })}.${format}`);
-        } else {
-            video.outPath = path.join(outDirs[index], finalTitle + '.' + format);
-        }
-
+       
+        video.outPath = path.join(outDirs[index], `${sanitizeWindowsName(finalTitle, { replacement: "_" })}.${format}`);
+        
     });
 
     return videos;


### PR DESCRIPTION
I noticed that the time parameter in output path formatting inserts colons in the name of the file, but that breaks file system constraints on windows (`:` is forbidden in file names), resulting in a `invalid argument` from ffmpeg.

I added a call to sanitize the video name when the platform is windows and also fixed a typo I saw.