### PR TITLE
Added concatenation function to downloadVideo

### DIFF
--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -16,6 +16,13 @@ export const argv: any = yargs.options({
         describe: 'The username used to log into Microsoft Stream (enabling this will fill in the email field for you).',
         demandOption: false
     },
+    concat: { // FOR CONCATENATING VIDEOS
+        alias: 'c',
+        describe: 'If enabled concatenate videos in the order they are typed in the file',
+        type: 'boolean',
+        default: false,
+        demandOption: false
+    },
     videoUrls: {
         alias: 'i',
         describe: 'List of urls to videos or Microsoft Stream groups.',

--- a/src/CommandLineParser.ts
+++ b/src/CommandLineParser.ts
@@ -16,13 +16,6 @@ export const argv: any = yargs.options({
         describe: 'The username used to log into Microsoft Stream (enabling this will fill in the email field for you).',
         demandOption: false
     },
-    concat: { // FOR CONCATENATING VIDEOS
-        alias: 'c',
-        describe: 'If enabled concatenate videos in the order they are typed in the file',
-        type: 'boolean',
-        default: false,
-        demandOption: false
-    },
     videoUrls: {
         alias: 'i',
         describe: 'List of urls to videos or Microsoft Stream groups.',
@@ -110,7 +103,14 @@ export const argv: any = yargs.options({
         type: 'boolean',
         default: false,
         demandOption: false
-    }
+    },
+    concat: {
+        alias: 'c',
+        describe: 'If enabled concatenate videos in the order they are typed in the file',
+        type: 'boolean',
+        default: false,
+        demandOption: false
+    },
 })
 .wrap(120)
 .check(() => noArguments())

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -347,6 +347,31 @@ async function downloadVideo(videoGUIDs: Array<string>,
         logger.info(`Video no.${videos.indexOf(video) + 1} downloaded!!\n\n`);
     }
 
+    // START CONCATENATE
+    if(argv.concat){
+        logger.info("Concatenating videos...");
+        let concatFiles = "";
+        let concatName = `videos_concatenated ${videos.length}`;
+        for(const video of videos){
+            concatFiles += ("file '" + video.outPath + "'\n");
+            logger.info("file " + video.outPath);
+        }
+
+        // Create a file containg all videos path
+        await fs.promises.writeFile('files.txt', concatFiles);
+        
+        const concatCommand = (
+            // set video concat settings
+            `ffmpeg -f concat -safe 0 -protocol_whitelist file,http,https,tcp,tls,crypto ` +
+            // add video list
+            `-i files.txt ` +
+            // copy codec and output path
+            `-c copy videos/${concatName}.mkv`
+        );
+        execSync(concatCommand, {stdio: 'ignore'}); //TODO: remove video files after they have been concateated
+    }
+    // END CONCATENATE
+
     logger.info('Exiting, this will take some seconds...');
 
     logger.debug('[destreamer] closing downloader socket');

--- a/src/destreamer.ts
+++ b/src/destreamer.ts
@@ -350,6 +350,7 @@ async function downloadVideo(videoGUIDs: Array<string>,
     // START CONCATENATE
     if(argv.concat){
         logger.info("Concatenating videos...");
+        
         let concatFiles = "";
         let concatName = `videos_concatenated ${videos.length}`;
         for(const video of videos){
@@ -358,7 +359,7 @@ async function downloadVideo(videoGUIDs: Array<string>,
         }
 
         // Create a file containg all videos path
-        await fs.promises.writeFile('files.txt', concatFiles);
+        fs.writeFileSync('files.txt', concatFiles);
         
         const concatCommand = (
             // set video concat settings
@@ -366,9 +367,13 @@ async function downloadVideo(videoGUIDs: Array<string>,
             // add video list
             `-i files.txt ` +
             // copy codec and output path
-            `-c copy videos/${concatName}.mkv`
+            `-c copy 'videos/${concatName}'.mkv`
         );
-        execSync(concatCommand, {stdio: 'ignore'}); //TODO: remove video files after they have been concateated
+        try{
+            execSync(concatCommand, {stdio: 'ignore'});
+        }catch(err){
+            logger.error("There was an error during video merging");
+        }
     }
     // END CONCATENATE
 


### PR DESCRIPTION
Added a flag ("-c" stands for concatenate). If enabled, destreamer (when downloads are completed) concatenate videos into a single one (using "FFmpeg concat" command).
It doesn't remove single videos after concatenation yet.