### PR TITLE
fix SharePoint url regex to apply to more sites

### DIFF
--- a/src/Downloaders.ts
+++ b/src/Downloaders.ts
@@ -177,7 +177,7 @@ export async function downloadStreamVideo(videoUrls: Array<VideoUrl>): Promise<v
 
 // TODO: complete overhaul of this function
 export async function downloadShareVideo(videoUrls: Array<VideoUrl>): Promise<void> {
-    const shareUrlRegex = new RegExp(/(?<domain>https:\/\/.+\.sharepoint\.com)(?<baseSite>\/sites\/.*?)(?:(?<filename>\/.*\.mp4)|\/.*id=(?<paramFilename>.*mp4))/);
+    const shareUrlRegex = new RegExp(/(?<domain>https:\/\/.+\.sharepoint\.com)(?<baseSite>\/(?:teams|sites)\/.*?)(?:(?<filename>\/.*\.mp4)|\/.*id=(?<paramFilename>.*mp4))/);
 
     logger.info('Downloading SharePoint videos...\n\n');
 


### PR DESCRIPTION
My college's SharePoint uses the ```"<domain>.sharepoint.com/teams/<team>/?id=<filePath>"``` format.

I have updated the regex to also consider this type of URL as valid.

I have built and tested this and it works.

![image](https://user-images.githubusercontent.com/49993491/138260146-a6eb7457-f20f-407f-a741-b9a234219c13.png)
