### PR TITLE
Fix: "regex aria2" for multilingual aria2 system output

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -214,11 +214,11 @@ export function checkRequirements(): void {
     }
 
     try {
-        const versionRegex = new RegExp(/aria2 version (.*)/);
-        const aira2Ver: string = execSync('aria2c --version').toString().split('\n')[0];
+        const versionRegex = new RegExp(/aria2 [a-z]+ ([0-9.]+)/);
+        const aria2Ver: string = execSync('aria2c --version').toString();
 
-        if (versionRegex.test(aira2Ver)) {
-            logger.verbose(`Using ${aira2Ver}\n`);
+        if (versionRegex.test(aria2Ver)) {
+            logger.verbose(`Using ${aria2Ver}\n`);
         }
         else {
             throw new Error();


### PR DESCRIPTION
On some linux systems the `aria2 --version` command provides output in the system language. The previously used regex only works for English output.
With my edits I have made it possible to verify the version of aria2 even for systems with a different system language. I also removed line splitting of the output, which is not necessary for the new regex.