### PR TITLE
Add `personal` to URL regex to apply to more sites

### DIFF
--- a/src/ApiClient.ts
+++ b/src/ApiClient.ts
@@ -175,7 +175,7 @@ export class ShareApiClient {
                 AddRequiredFields: true
             }
         };
-        const url = `${this.site}/_api/web/GetListUsingPath(DecodedUrl=@a1)/RenderListDataAsStream?@a1='${filePath}'`;
+        const url = `${this.site}/_api/web/GetListUsingPath(DecodedUrl=@a1)/RenderListDataAsStream?@a1='${encodeURIComponent(filePath)}'`;
 
         logger.verbose(`Requesting video info for '${url}'`);
         const info = await this.axiosInstance.post(url, payload, {

--- a/src/Downloaders.ts
+++ b/src/Downloaders.ts
@@ -177,7 +177,7 @@ export async function downloadStreamVideo(videoUrls: Array<VideoUrl>): Promise<v
 
 // TODO: complete overhaul of this function
 export async function downloadShareVideo(videoUrls: Array<VideoUrl>): Promise<void> {
-    const shareUrlRegex = new RegExp(/(?<domain>https:\/\/.+\.sharepoint\.com).*?(?<baseSite>\/(?:teams|sites)\/.*?)(?:(?<filename>\/.*\.mp4)|\/.*id=(?<paramFilename>.*mp4))/);
+    const shareUrlRegex = new RegExp(/(?<domain>https:\/\/.+\.sharepoint\.com).*?(?<baseSite>\/(?:teams|sites|personal)\/.*?)(?:(?<filename>\/.*\.mp4)|\/.*id=(?<paramFilename>.*mp4))/);
 
     logger.info('Downloading SharePoint videos...\n\n');
 


### PR DESCRIPTION
Hi, this PR is to add `personal` part of the URL (now they are using OneDrive for Business to store all the recordings).
And I have issues when the file name is not `encodeURIComponent`-ed. Therefore, this PR is also to fix this issue.