### PR TITLE
Fix regex for aria2 check on non-English machines

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -214,7 +214,7 @@ export function checkRequirements(): void {
     }
 
     try {
-        const versionRegex = new RegExp(/aria2 version (.*)/);
+        const versionRegex = new RegExp(/aria2 .* (\d+\.\d+\.\d+.*)/);
         const aira2Ver: string = execSync('aria2c --version').toString().split('\n')[0];
 
         if (versionRegex.test(aira2Ver)) {


### PR DESCRIPTION
Solves issue #474.
Solution is based on aria2's official versioning scheme (see [Versioning and release schedule](https://github.com/aria2/aria2/blob/f4cbc7bb315b1687679e6ab94648c2685a9e9668/README.rst#versioning-and-release-schedule) in the project's README):

```
We use 3 numbers for aria2 version: MAJOR.MINOR.PATCH.
```