### PR TITLE
Changed 'aria2c --version' to 'LANG=en_US.UTF-8 aria2c --version' for consistent environment

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -215,7 +215,7 @@ export function checkRequirements(): void {
 
     try {
         const versionRegex = new RegExp(/aria2 version (.*)/);
-        const aira2Ver: string = execSync('aria2c --version').toString().split('\n')[0];
+        const aira2Ver: string = execSync('LANG=en_US.UTF-8 aria2c --version').toString().split('\n')[0];
 
         if (versionRegex.test(aira2Ver)) {
             logger.verbose(`Using ${aira2Ver}\n`);

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -215,10 +215,10 @@ export function checkRequirements(): void {
 
     try {
         const versionRegex = new RegExp(/aria2 version (.*)/);
-        const aira2Ver: string = execSync('LANG=en_US.UTF-8 aria2c --version').toString().split('\n')[0];
+        const aria2Ver: string = execSync('LANG=en_US.UTF-8 aria2c --version').toString().split('\n')[0];
 
-        if (versionRegex.test(aira2Ver)) {
-            logger.verbose(`Using ${aira2Ver}\n`);
+        if (versionRegex.test(aria2Ver)) {
+            logger.verbose(`Using ${aria2Ver}\n`);
         }
         else {
             throw new Error();


### PR DESCRIPTION
In my environment, `$LANG=ja_JP.UTF-8` is set by default and the output of `aria2c --version` is output in Japanese.

In that case, the value of the `aria2Ver` variable is "aria2 バージョン" instead of "aria2 version", which does not match `versionRegex = RegExp(/aria2 version (. *)/)` and followiing process throws an error.

https://github.com/snobu/destreamer/blob/e93ad80ef6fcffb7d25936ffb4c9cf9a3d2d6f4e/src/Utils.ts#L216-L229

To solve this problem, change `execSync('aria2c --version')` to `execSync('LANG=en_US.UTF-8 aria2c --version')` so that the output of the command `aria2c --version` is always in English.